### PR TITLE
added cache-control: public for gc cdn

### DIFF
--- a/1.13.6-alpine/templates/default.conf
+++ b/1.13.6-alpine/templates/default.conf
@@ -36,12 +36,16 @@ server {
         location ~* /files/styles/ {
             access_log off;
             expires 30d;
+            # Google cloud cdn needs a Cache-Control: public header.
+            add_header Cache-Control "public";
             try_files $uri @drupal;
         }
 
         location ~* /sites/.+/files/.+\.txt {
             access_log off;
             expires 30d;
+            # Google cloud cdn needs a Cache-Control: public header.
+            add_header Cache-Control "public";
             tcp_nodelay off;
             open_file_cache max=3000 inactive=120s;
             open_file_cache_valid 45s;
@@ -52,6 +56,8 @@ server {
         location ~* files/advagg_(?:css|js)/ {
           access_log off;
           expires max;
+          # Google cloud cdn needs a Cache-Control: public header.
+          add_header Cache-Control "public";
           add_header ETag "";
           add_header Accept-Ranges '';
           add_header Last-Modified 'Wed, 20 Jan 1988 04:20:42 GMT';
@@ -73,6 +79,8 @@ server {
         location ~* ^.+\.(?:css|cur|js|jpe?g|gif|htc|ico|png|xml|otf|ttf|eot|woff|woff2|svg|svgz)$ {
             access_log off;
             expires 30d;
+            # Google cloud cdn needs a Cache-Control: public header.
+            add_header Cache-Control "public";
             tcp_nodelay off;
             open_file_cache max=3000 inactive=120s;
             open_file_cache_valid 45s;
@@ -87,6 +95,8 @@ server {
 
         location ~* ^.+\.(?:pdf|pptx?)$ {
             expires 30d;
+            # Google cloud cdn needs a Cache-Control: public header.
+            add_header Cache-Control "public";
             tcp_nodelay off;
         }
 
@@ -169,6 +179,8 @@ server {
 
     location = /favicon.ico {
         expires 30d;
+        # Google cloud cdn needs a Cache-Control: public header.
+        add_header Cache-Control "public";
         try_files /favicon.ico @empty;
     }
 
@@ -178,6 +190,8 @@ server {
 
     location @empty {
         expires 30d;
+        # Google cloud cdn needs a Cache-Control: public header.
+        add_header Cache-Control "public";
         empty_gif;
     }
 


### PR DESCRIPTION
 # Google cloud cdn needs a Cache-Control: public header.
 add_header Cache-Control "public";