### PR TITLE
suppress fcgi date haeader to avoid stale date

### DIFF
--- a/1.13.6-alpine/templates/default.conf
+++ b/1.13.6-alpine/templates/default.conf
@@ -16,6 +16,7 @@ server {
     index index.php;
 
     include fastcgi.conf;
+    fastcgi_hide_header “Date”; 
     #httpsredirect
 
     location / {


### PR DESCRIPTION
Nginx should always respond with a fresh Date header ignoring the php set header Date.
php Date could come from cached item and result in out of sync, this will avoid caching into GC CDN.