### PR TITLE
Do not include redirects file if not existing.

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -38,8 +38,5 @@ for filename in /etc/nginx/conf.d/custom/*.conf; do
   fi
 done
 
-# Attempt to create the redirects files if not present.
-touch /etc/nginx/conf.d/redirects.map
-
 envsubst '${NGINX_PHP_READ_TIMEOUT}' < /templates/fastcgi.conf > /etc/nginx/fastcgi.conf
 exec nginx -g "daemon off;"

--- a/templates/default.conf
+++ b/templates/default.conf
@@ -9,7 +9,7 @@ map $http_x_forwarded_proto $fastcgi_https {
 }
 
 map $uri $new_uri {
-  include /etc/nginx/conf.d/redirects.map;
+  include /etc/nginx/conf.d/redirects[.]map;
 }
 
 # Custom configuration to be included dynamically.


### PR DESCRIPTION
The inclusion of the redirects map file should happen only when the file exists . 