### PR TITLE
Fix map redirect with query parameters

### DIFF
--- a/templates/default.conf
+++ b/templates/default.conf
@@ -8,7 +8,7 @@ map $http_x_forwarded_proto $fastcgi_https {
     https on;
 }
 
-map $uri $new_uri {
+map $request_uri $new_uri {
   include /etc/nginx/conf.d/redirects[.]map;
 }
 


### PR DESCRIPTION
This will fix redirects for urls with query parameters as:

`/faq-single.php?faq=spididol-eccipienti /a-cosa-serve;`