### PR TITLE
return 404 for PHP files

### DIFF
--- a/templates/default.conf
+++ b/templates/default.conf
@@ -89,6 +89,11 @@ server {
     }
 
     location ~ \.php$ {
+        # We prevent from executing all php scripts except for "index.php" and "update.php".
+        # When opening a non "index.php" file we return a 404 error served
+        # from the application (we pass through index.php).
+        try_files /index.php =404;
+        
         include fastcgi.conf;
         fastcgi_param SCRIPT_FILENAME $request_filename;
         fastcgi_pass php;


### PR DESCRIPTION
Return an application 404 (Drupal) error page when opening existing php files different from index.php (this will not prevent to open update.php). Non existing php files will also return a application 404.