### PR TITLE
Allow all files in well-known path

### DIFF
--- a/templates/default.conf
+++ b/templates/default.conf
@@ -79,7 +79,7 @@ server {
     }
 
     location ~* ^/\.well-known/.*\.php$ {
-        deny all;
+        return 403;
     }
 
     location ~* ^/\.well-known(/|$) {

--- a/templates/default.conf
+++ b/templates/default.conf
@@ -78,11 +78,12 @@ server {
         return 403;
     }
 
+    location ~* ^/\.well-known/.*\.php$ {
+        deny all;
+    }
+
     location ~* ^/\.well-known(/|$) {
-        location ~* ^/\.well-known/.*\.txt$ {
-            allow all;
-        }
-        return 403;
+        allow all;
     }
 
     location ~* \.(txt|log)$ {

--- a/templates/default.conf
+++ b/templates/default.conf
@@ -83,7 +83,10 @@ server {
     }
 
     location ~* ^/\.well-known(/|$) {
-        allow all;
+        location ~* ^/\.well-known/.*\.txt$ {
+            allow all;
+        }
+        return 403;
     }
 
     location ~* \.(txt|log)$ {

--- a/templates/default.conf
+++ b/templates/default.conf
@@ -74,13 +74,20 @@ server {
         try_files $uri @rewrite;
     }
 
+    location ~ \..*/.*\.php$ {
+        return 403;
+    }
+
+    location ~* ^/\.well-known(/|$) {
+        location ~* ^/\.well-known/.*\.txt$ {
+            allow all;
+        }
+        return 403;
+    }
+
     location ~* \.(txt|log)$ {
         allow 192.168.0.0/16;
         deny all;
-    }
-
-    location ~ \..*/.*\.php$ {
-        return 403;
     }
 
     location ~ ^/sites/.*/private/ {
@@ -89,10 +96,6 @@ server {
 
     location ~ ^/sites/[^/]+/files/.*\.php$ {
         deny all;
-    }
-
-    location ~* ^/.well-known/ {
-        allow all;
     }
 
     location ~ (^|/)\. {


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Places `/.well-known/` location block before the `.txt|log` deny rule so all resources under that path are publicly accessible

- Adds an explicit `deny all` rule for PHP files under `/.well-known/` to prevent PHP source leakage

- Ensures `/.well-known/` path is not restricted by `.txt|log` deny rules, supporting ACME challenges (tokens without file extensions), `security.txt`, and other well-known endpoints


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["robots.txt location block"] -- "followed by" --> B["/.well-known/*.php deny all"]
  B -- "followed by" --> C["/.well-known/ allow all"]
  C -- "followed by" --> D[".txt|log deny rule"]
  D -- "followed by" --> E["other location blocks"]
```


___