### PR TITLE
chore(nginx): update base image to 1.30.2 and modernize CI

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,6 +9,7 @@ env:
   IMAGE_NAME: docker-php-drupal-nginx
   TAG_D8: d8
   TAG_D8_RL: d8-rootless
+  PLATFORMS: linux/amd64,linux/arm64
 
 jobs:
   test:
@@ -16,33 +17,35 @@ jobs:
       matrix:
         version:
           [
+            1.30.2-alpine-slim,
             1.26.0-alpine-slim,
             1.25.5-alpine-slim,
             1.25.3-alpine-slim,
             1.25.1-alpine-slim,
-            1.23.3-alpine-slim,
-            1.23.3-alpine,
-            1.23.1-alpine,
           ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build images
         run: |
           docker buildx build --load . \
             --file Dockerfile \
+            --cache-from type=gha,scope=${{ matrix.version }}-root \
+            --cache-to type=gha,mode=max,scope=${{ matrix.version }}-root \
             --tag $IMAGE_NAME:${{ matrix.version }}.d8 \
             --build-arg NGINX_IMAGE_TAG=${{ matrix.version }} \
             --build-arg user=root
           docker buildx build --load . \
             --file Dockerfile \
+            --cache-from type=gha,scope=${{ matrix.version }}-rootless \
+            --cache-to type=gha,mode=max,scope=${{ matrix.version }}-rootless \
             --tag $IMAGE_NAME:${{ matrix.version }}.d8-rootless \
             --build-arg NGINX_IMAGE_TAG=${{ matrix.version }} \
             --build-arg user=1001
@@ -59,33 +62,31 @@ jobs:
       matrix:
         version:
           [
+            1.30.2-alpine-slim,
             1.26.0-alpine-slim,
             1.25.5-alpine-slim,
             1.25.3-alpine-slim,
             1.25.1-alpine-slim,
-            1.23.3-alpine-slim,
-            1.23.3-alpine,
-            1.23.1-alpine,
           ]
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/feature/d8'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # Refs https://github.com/docker/login-action#github-container-registry
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and push images to GitHub Container Registry
         run: |
@@ -93,21 +94,22 @@ jobs:
           # Change all uppercase to lowercase.
           IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
           echo IMAGE_ID=$IMAGE_ID
-          PLATFORMS="${{ matrix.version == '1.13.6-alpine' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}"
           echo PLATFORMS=$PLATFORMS
           docker buildx build --push . --platform "$PLATFORMS" \
             --file Dockerfile \
+            --cache-from type=gha,scope=${{ matrix.version }}-root \
             --tag $IMAGE_ID:${{ matrix.version }}.d8 \
             --build-arg NGINX_IMAGE_TAG=${{ matrix.version }} \
             --build-arg user=root
           docker buildx build --push . --platform "$PLATFORMS" \
             --file Dockerfile \
+            --cache-from type=gha,scope=${{ matrix.version }}-rootless \
             --tag $IMAGE_ID:${{ matrix.version }}.d8-rootless \
             --build-arg NGINX_IMAGE_TAG=${{ matrix.version }} \
             --build-arg user=1001
 
       - name: Push d8 tag
-        if: ${{ matrix.version == '1.13.6-alpine' }}
+        if: ${{ matrix.version == '1.30.2-alpine-slim' }}
         run: |
           IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
           # Change all uppercase to lowercase.

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -11,7 +11,7 @@ jobs:
   check-shell-scripts:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@master

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG NGINX_IMAGE_TAG=1.25.3-alpine-slim
+ARG NGINX_IMAGE_TAG=1.30.2-alpine-slim
 
 FROM nginx:${NGINX_IMAGE_TAG}
 
@@ -30,7 +30,7 @@ RUN chmod +x /docker-entrypoint.sh && \
     chmod 775 /var/log/nginx && \
     mkdir -p /var/run/nginx && \
     chmod 775 /var/run/nginx && \
-    sed -i 's|/var/run/nginx.pid|/var/run/nginx/nginx.pid|g' /etc/nginx/nginx.conf && \
+    sed -i 's|pid .*nginx\.pid;|pid /var/run/nginx/nginx.pid;|' /etc/nginx/nginx.conf && \
     find /templates -type d -exec chmod 775 {} + && \
     chmod 664 /etc/nginx/fastcgi.conf && \
     chmod 664 /etc/nginx/conf.d/default.conf

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,9 @@
 # Add tags for the official nginx image to build
-IMAGE_TAGS ?= 1.23.1-alpine \
-	1.23.3-alpine \
-	1.23.3-alpine-slim \
-	1.25.1-alpine-slim \
+IMAGE_TAGS ?= 1.25.1-alpine-slim \
 	1.25.3-alpine-slim \
 	1.25.5-alpine-slim \
-	1.26.0-alpine-slim
+	1.26.0-alpine-slim \
+	1.30.2-alpine-slim
 
 IMAGE_NAME ?= sparkfabrik/docker-php-drupal-nginx
 

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -5,7 +5,7 @@ set -e
 
 BASE="$(dirname "${0}")"
 IMAGE_NAME=${IMAGE_NAME:-sparkfabrik/docker-php-drupal-nginx}
-IMAGE_TAG=${IMAGE_TAG:-1.13.6-alpine.d8}
+IMAGE_TAG=${IMAGE_TAG:-1.30.2-alpine-slim.d8}
 IMAGE_USER=${IMAGE_USER:-root}
 BASE_TESTS_PORT=${BASE_TESTS_PORT:-80}
 OVERRIDES_NGINX_PORT=${OVERRIDES_NGINX_PORT:-4321}


### PR DESCRIPTION
## Summary

Updates the nginx base image to **1.30.2-alpine-slim** (latest stable) and modernizes the CI workflows.

## Changes

### nginx version
- Add `1.30.2-alpine-slim` as the new default base image (`Dockerfile`), build matrix entry (`Makefile`, `docker-publish.yml`), and rolling-tag source.
- Prune build tags below `1.25.1` (dropped `1.23.1-alpine`, `1.23.3-alpine`, `1.23.3-alpine-slim`). Matrix is now `1.25.1`, `1.25.3`, `1.25.5`, `1.26.0`, `1.30.2` (all alpine-slim).

### Rootless pid fix (blocker)
- Newer nginx alpine bases moved the pid directive from `/var/run/nginx.pid` to `/run/nginx.pid`. The old `sed` no longer matched, so the rootless image (`user 1001`) died at startup with `open() "/run/nginx.pid" failed (13: Permission denied)`.
- Rewrote the `sed` to match the pid directive regardless of its path — future-proof against further base changes.

### CI improvements
- **Fix rolling `d8`/`d8-rootless` tag push**: it was gated on `matrix.version == '1.13.6-alpine'`, a version absent from the matrix, so the consumer-facing tags were never updated. Now gated on `1.30.2-alpine-slim`.
- Removed the dead `1.13.6-alpine` `PLATFORMS` ternary; hoisted `PLATFORMS` to a workflow-level `env` var.
- Added scoped GitHub Actions build cache (`type=gha`, per version+user scope) so `deploy` reuses `test`'s layers.
- Bumped marketplace actions: `checkout` v4/v3 → **v6**, `setup-qemu-action` v3 → **v4**, `setup-buildx-action` v3 → **v4**, `login-action` v2 → **v4**.

## Testing

Built and ran the full test suite locally on `1.30.2-alpine-slim`, both root and rootless variants — all pass. The pid fix was verified by reproducing the rootless startup failure before the fix and confirming it resolved after.
