### PR TITLE
docs: align README and CHANGELOG with current features, add AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,187 @@
+# AGENTS.md
+
+Instructions for coding agents working on this repository. Complements
+`README.md` with agent-specific technical guidance.
+
+## Project Overview
+
+This repository builds the `docker-php-drupal-nginx` Docker image: an nginx
+front-end for PHP/Drupal 8+ applications. The image ships a single placeholder
+`server` configuration that is rendered at container start, plus a set of
+opt-in features (basic auth, CORS, HSTS, CSP, structured logging, object-storage
+asset proxying, forbidden locations, redirects) toggled through environment
+variables.
+
+There is no application code here — the deliverable is the image itself.
+
+**Tech stack:** nginx (alpine-slim base), POSIX shell (entrypoint + tests),
+`envsubst` templating, Docker Buildx, GitHub Actions.
+
+### Architecture
+
+- `Dockerfile` — builds the image from a parametrised `nginx:${NGINX_IMAGE_TAG}`
+  base. The `user` build-arg (`root` or `1001`) selects the flavour.
+- `docker-entrypoint.sh` — reads environment variables, renders the templates
+  with `envsubst`, and assembles the final nginx configuration.
+- `templates/` — nginx config templates and fragments rendered by the entrypoint.
+- `config/conf.d/` — static config copied into the image.
+- `tests/` — the bash test harness (`tests.sh`) and its expectation fixtures.
+
+## Setup
+
+Everything runs in Docker via `make`. No local nginx is required.
+
+```bash
+make build      # build every tag in IMAGE_TAGS, root flavour (.d8)
+make test       # run the test suite against the built root images
+make all        # build + test, both root and rootless flavours
+```
+
+Run a single tag/flavour:
+
+```bash
+NGINX_IMAGE_TAG=1.30.2-alpine-slim BUILD_IMAGE_TAG_SUFFIX=d8 BUILD_IMAGE_USER=root \
+  make base-build-template
+IMAGE_TAG=1.30.2-alpine-slim.d8 ./tests/tests.sh
+```
+
+The set of base versions built locally lives in `IMAGE_TAGS` at the top of the
+`Makefile`.
+
+## Key Conventions
+
+- **Image-build repo.** Changes are to the Dockerfile, entrypoint, templates,
+  config, or tests — never to application code.
+- **Features are env-var driven.** New behaviour is added as a template (or
+  fragment) plus the matching `envsubst` variable list in `docker-entrypoint.sh`.
+  Every variable that a template consumes must be added to the relevant
+  `envsubst '...'` allow-list, or it will be stripped to empty.
+- **Document every new variable** in `README.md` (the `Env variables` list) and
+  add an entry to the `[Unreleased]` section of `CHANGELOG.md`.
+- **Two flavours per version:** `:<version>.d8` (root) and
+  `:<version>.d8-rootless` (user `1001`), selected by the `user` build-arg.
+- **CI version list is the single source of truth.** The published versions are
+  defined once in the `NGINX_TAGS` env variable in
+  `.github/workflows/docker-publish.yml`; `PRIMARY_TAG` selects the version that
+  also gets the rolling `:d8` / `:d8-rootless` tags. Keep `IMAGE_TAGS` in the
+  `Makefile` aligned with `NGINX_TAGS` when changing the supported set.
+
+## Code Style
+
+- **Shell**: validated with ShellCheck. Run the repo's dockerised check before
+  committing:
+
+  ```bash
+  make shellcheck
+  ```
+
+- Keep `envsubst` variable allow-lists explicit and in sync across the
+  catch-all, default, subfolder, and fragment rendering steps in
+  `docker-entrypoint.sh`.
+- Match the existing POSIX-sh style of `docker-entrypoint.sh` (no bashisms in
+  the entrypoint; the test harness uses bash).
+
+## Git Workflow
+
+### Commits
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/):
+
+```
+<type>(<scope>): <description>
+```
+
+**Types:** `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `ci`, `perf`, `build`.
+**Scope** is optional — use the affected component (e.g. `nginx`, `ci`, `tests`).
+Keep the description lowercase, imperative, no trailing period.
+
+Every commit must carry an `Assisted-by` trailer identifying the agent and
+model, applied via `git commit --trailer`.
+
+### Branching
+
+- Branch naming: `feat/`, `fix/`, `chore/`, `ci/`, `test/`, `docs/` prefix +
+  kebab-case description (e.g. `ci/native-multiarch-release-strategy`).
+- **The default branch is `feature/d8`, not `main`/`master`.** Never push
+  directly to it — always branch and open a pull request targeting `feature/d8`.
+
+### Rebasing
+
+- Rebase onto `feature/d8` before pushing. No merge commits.
+- Use `--force-with-lease` (never `--force`) after rebasing.
+
+## Testing
+
+`make test` builds the images and runs `tests/tests.sh` against each tag in
+`IMAGE_TAGS`. The harness boots each image, exercises HTTP behaviour, response
+headers, basic auth, CORS, redirects, and the rootless user, and compares
+against the fixtures under `tests/expectations` and `tests/overrides/`.
+
+- Test harness: `tests/tests.sh` (bash), helpers in `tests/lib/functions.sh`.
+- Run one image directly:
+  `IMAGE_TAG=<version>.d8 ./tests/tests.sh`
+- Rootless run:
+  `IMAGE_TAG=<version>.d8-rootless IMAGE_USER="unknown uid 1001" BASE_TESTS_PORT=8080 ./tests/tests.sh`
+- The bare runner's default `IMAGE_TAG` is set at the top of `tests/tests.sh`;
+  read it there rather than assuming a value.
+
+## CI/CD
+
+The project uses GitHub Actions. Builds and pushes run only on the `feature/d8`
+branch; pull requests run the `prepare` and `test` jobs.
+
+### `docker-publish.yml`
+
+`.github/workflows/docker-publish.yml` is the source of truth; read it for the
+exact steps. The pipeline is four jobs:
+
+- `prepare` — surface `NGINX_TAGS` as a job output the matrices read via `fromJSON`.
+- `test` — build each version × flavour natively (amd64, `--load`) and run `tests.sh`.
+- `build` — build each version × flavour × arch on native runners and push by digest.
+- `merge` — assemble the per-arch digests into the final multi-arch manifests.
+
+### `qa.yml`
+
+Runs ShellCheck on the shell scripts.
+
+## Command Safety
+
+### Safe (run autonomously)
+
+Read-only or local, non-destructive:
+
+- `make build`, `make test`, `make all`, `make shellcheck`
+- `./tests/tests.sh` (and its `IMAGE_TAG=...` variants)
+- `git status`, `git log`, `git diff`
+- `docker buildx imagetools inspect <ref>`
+
+### Dangerous (ask user first)
+
+State-changing or outward-facing:
+
+- `git push`, opening or editing pull requests
+- `docker push`, `docker buildx build --push`
+- Editing `.github/workflows/*` (affects published images)
+- Bumping the nginx base version (`NGINX_TAGS` / `IMAGE_TAGS` / `PRIMARY_TAG`)
+
+### Destructive (never run)
+
+- `git push --force` (use `--force-with-lease` only, and only after rebase)
+- `rm -rf` on tracked paths
+- Deleting GHCR tags or packages
+- Force-pushing to `feature/d8`
+
+## Important Rules
+
+- Any new template variable must be added to the matching `envsubst` allow-list
+  in `docker-entrypoint.sh`, or it renders empty. This is the most common
+  silent failure in this repo.
+- Document new env variables in `README.md` and under `[Unreleased]` in
+  `CHANGELOG.md`.
+- Keep `IMAGE_TAGS` (Makefile) and `NGINX_TAGS` (workflow) aligned.
+- Verify the latest nginx version against the registry before bumping — never
+  assume it from memory.
+- Build and test only in Docker via `make`; run `make shellcheck` before
+  committing shell changes.
+- Default branch is `feature/d8`: branch and open a PR, never push to it
+  directly. See [Command Safety](#command-safety) for the full tier list.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,74 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- New `1.30.2-alpine-slim` nginx base image, which is now the default and the
+  source of the rolling `:d8` / `:d8-rootless` tags. Earlier `alpine-slim`
+  versions (`1.25.1`, `1.25.3`, `1.25.5`, `1.26.0`) are also published.
+- Basic authentication support through the `NGINX_BASIC_AUTH_USER`,
+  `NGINX_BASIC_AUTH_PASS`, `NGINX_BASIC_AUTH_REALM` and `NGINX_BASIC_AUTH_FILE`
+  environment variables, with `NGINX_BASIC_AUTH_EXCLUDE_LOCATIONS` and
+  `NGINX_BASIC_AUTH_EXCLUDE_REQUEST_URIS` to exempt specific paths (for example
+  a health-check probe). `OPTIONS` requests are never challenged.
+- CORS support through `NGINX_CORS_ENABLED`, with optional `NGINX_CORS_DOMAINS`
+  to restrict CORS to a list of allowed origins.
+- Forbidden locations that deny access to `composer.json`/`composer.lock` and
+  `package.json`/`package-lock.json`, with a configurable response code via
+  `NGINX_FORBIDDEN_LOCATIONS_EXIT_CODE`. They are activated automatically when
+  `ENV` is not local.
+- `Content-Security-Policy` header support through the `NGINX_CSP_HEADER`
+  environment variable.
+- Object storage (s3fs) asset streaming and the lazy assets aggregator
+  introduced in Drupal 10.1, through `NGINX_ASSETS_STREAM_OVER_S3`,
+  `NGINX_OSB_ASSETS_PATH` and `DRUPAL_ASSETS_FILES_PATH`.
+- `NGINX_OSB_RESOLVER_ENFORCE_IPV6_OFF` to enforce `ipv6=off` on the object
+  storage resolver.
+- HTTPS redirect support through `NGINX_HTTPSREDIRECT`, honouring the original
+  protocol from the `X-Forwarded-Proto` header.
+- Configurable request body size through `NGINX_CLIENT_MAX_BODY_SIZE`
+  (default `200M`).
+- Configurable gzip compression through `NGINX_GZIP_ENABLE`.
+- Configurable catch-all server return code through `NGINX_CATCHALL_RETURN_CODE`.
+- `DRUPAL_PUBLIC_FILES_PATH` and `NGINX_CACHE_CONTROL_HEADER` to control the
+  public files location and its caching policy.
+- The forwarded `User-Agent` is now passed to PHP-FPM in the fastcgi parameters.
+- The `robots.txt` route can be overridden by PHP code.
+- Rootless image flavour, published with the `-rootless` tag suffix.
+
+### Changed
+
+- The default base image is now `1.30.2-alpine-slim`; nginx versions older than
+  `1.25.1` are no longer built.
+- Structured logging is configured across all server definitions, and the log
+  format includes the `X-Forwarded-For` value.
+- The CI workflow was modernized: GitHub Actions were upgraded, the QEMU
+  emulated build was replaced with native `amd64` and `arm64` runners that push
+  per-architecture digests merged into a final manifest, the version list is
+  sourced from a single `NGINX_TAGS` variable, GitHub Actions layer caching was
+  added, and the workflow declares least-privilege `permissions`.
+
+### Fixed
+
+- Rootless image failing to start because newer nginx base images moved the pid
+  directive to `/run/nginx.pid`; the pid rewrite now matches it regardless of
+  path.
+- The rolling `:d8` / `:d8-rootless` tags, which were gated on a base version
+  absent from the build matrix and therefore never published.
+
+### Security
+
+- Restored a restrictive `.well-known` handling that serves only `.txt` files
+  and denies PHP execution, preventing source code leakage.
+
+---
+
+The dated sections below were not maintained for a long period. They are kept
+for historical reference; all changes made since are collected under the
+`[Unreleased]` section above.
+
 ## 2022-12-14
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -3,6 +3,22 @@
 This docker image is designed to run PHP applications, with some
 specific configuration for Drupal 8.
 
+## Supported tags and architectures
+
+Images are published to GHCR for each nginx base version listed in the
+workflow's `NGINX_TAGS` variable, currently `1.30.2-alpine-slim` (the default),
+`1.26.0-alpine-slim`, `1.25.5-alpine-slim`, `1.25.3-alpine-slim` and
+`1.25.1-alpine-slim`. Every tag is built as a multi-arch manifest for
+`linux/amd64` and `linux/arm64`.
+
+Two flavours are published per version:
+
+- `:<version>.d8` — runs as `root`.
+- `:<version>.d8-rootless` — runs as the unprivileged user `1001` (see the
+  [Rootless feature](#rootless-feature) section).
+
+The primary version also publishes the rolling `:d8` and `:d8-rootless` tags.
+
 ## Customizations
 
 NGINX is configured dynamically by generating a `default.conf file.
@@ -105,6 +121,64 @@ The entrypoint file contains a list of environment variables that will be replac
 - `NGINX_CORS_ENABLED`: enable cors for `/` path and the caller origin header represented by `$http_origin` nginx variable (<https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin>) (default: `0`)
 - `NGINX_CORS_DOMAINS`: a list of CORS enabled domains to activate cors just for the specified ones (no default provided)
 - `NGINX_FORBIDDEN_LOCATIONS_EXIT_CODE`: a valid return code used as return value when the forbidden locations are hitted (default `200`)
+
+## Features
+
+Each feature below is driven by the environment variables documented in the
+[Env variables](#env-variables) section; this is a functional overview of what
+they enable.
+
+### Structured logging
+
+Access logs can be emitted in two formats, selected by `NGINX_ACCESS_LOG_FORMAT`:
+`main` (the classic nginx combined format) and `structured` (a JSON-style format
+that includes the `X-Forwarded-For` value, suitable for log aggregation). When
+`ENV` is not `loc` the structured format is enabled automatically across all
+server definitions.
+
+### CORS
+
+Set `NGINX_CORS_ENABLED=1` to emit CORS headers for the caller origin
+(`$http_origin`). To allow only specific origins, list them in
+`NGINX_CORS_DOMAINS`; CORS headers are then sent only when the request origin
+matches one of the configured domains.
+
+### Forbidden locations
+
+Sensitive files are denied at the nginx level, including `composer.json`,
+`composer.lock`, `package.json` and `package-lock.json`. The response code is
+configurable through `NGINX_FORBIDDEN_LOCATIONS_EXIT_CODE` (default `200`). The
+block is enabled automatically when `ENV` is not `loc`.
+
+### Object storage (s3fs) assets
+
+When Drupal serves files from an object storage bucket through s3fs, nginx can
+proxy the asset URLs to the bucket. `NGINX_OSB_BUCKET` and `NGINX_OSB_PUBLIC_PATH`
+configure the bucket proxy, `NGINX_OSB_RESOLVER` sets the DNS resolver used to
+reach it, and `NGINX_OSB_RESOLVER_ENFORCE_IPV6_OFF` enforces `ipv6=off` on that
+resolver. Bucket errors coming from the storage service are suppressed, and the
+Google GCS response headers are hidden by default (`HIDE_GOOGLE_GCS_HEADERS`).
+
+Starting from Drupal 10.1, the lazy assets aggregator can stream aggregated
+assets from the bucket: enable it with `NGINX_ASSETS_STREAM_OVER_S3=1` and
+configure `NGINX_OSB_ASSETS_PATH` and `DRUPAL_ASSETS_FILES_PATH`.
+
+### robots.txt and sitemap
+
+When `SITEMAP_URL` is set, its value is written as a `Sitemap:` directive into
+the served `robots.txt` for SEO purposes. The `robots.txt` route can also be
+overridden by application (PHP) code.
+
+### `.well-known` handling
+
+Requests under `/.well-known` are restricted: only `.txt` files are served and
+PHP execution is denied, to avoid leaking application source through that path.
+
+### HSTS in custom server fragments
+
+HSTS is controlled by the `NGINX_HSTS_*` variables. To also apply the
+`Strict-Transport-Security` header to a custom server defined in a fragment, add
+the `#hstsheader` annotation to that server definition.
 
 ## Rootless feature
 


### PR DESCRIPTION
## Summary

Aligns the project documentation with the features the image actually ships today, and adds agent-facing guidance.

## CHANGELOG

The changelog had not been maintained since `2022-12-14`. This adds a new `[Unreleased]` section at the top collecting every change made since then, reconstructed from git history and grouped Added / Changed / Fixed / Security. The original dated sections are kept verbatim for historical reference, behind a short note and a horizontal rule that mark the boundary between the maintained section and the frozen archive.

Highlights now recorded: basic auth, CORS, forbidden locations, CSP, object storage (s3fs) asset streaming and lazy assets, HTTPS redirect, configurable body size / gzip / catch-all code, structured logging, the rootless flavour, the nginx `1.30.2-alpine-slim` bump, the native multi-arch CI, the rootless pid-path fix, the rolling-tag fix and the `.well-known` hardening.

## README

The env-var list was already complete and accurate, but several features had no explanatory prose. This adds:

- A **Supported tags and architectures** section: published versions (sourced from `NGINX_TAGS`), multi-arch `amd64`/`arm64`, the `.d8` and `-rootless` flavours, and the rolling `:d8` / `:d8-rootless` tags.
- A **Features** overview with short subsections for structured logging, CORS, forbidden locations, object storage (s3fs) assets, robots.txt / sitemap, `.well-known` handling, and the HSTS `#hstsheader` custom-fragment annotation.

## AGENTS.md

Adds an `AGENTS.md` ([agents.md](https://agents.md/) format) with agent-facing guidance for this image-build repo: setup via `make`, the env-var/template/`envsubst` feature model (the `envsubst` allow-list gotcha is called out), the single `NGINX_TAGS` source, the `.d8` / `-rootless` flavours, ShellCheck, the GitHub Actions pipeline, command-safety tiers, and the git workflow (default branch is `feature/d8`). Version-specific values are referenced by file rather than hardcoded, to avoid staleness. `CLAUDE.md` is added as a relative symlink to `AGENTS.md` so tools that look up `CLAUDE.md` share the same source.

No behavioural changes — documentation only.
