### PR TITLE
fix(tests): retry the first request to absorb nginx startup race

### DIFF
--- a/tests/lib/functions.sh
+++ b/tests/lib/functions.sh
@@ -485,13 +485,24 @@ get_http_test_output() {
   fi
 
   debug "Get the data: docker run --rm ${DOCKER_TEST_IMAGE} --ignore-stdin -p HhBb ${HTTPIE_ADDITIONAL_OPTIONS} GET ${DOCKER_TEST_PROTO}://${DOCKER_TEST_IP}:${DOCKER_TEST_PORT}/${DOCKER_TEST_PATH} ${HTTPIE_REQ_HEADERS}"
-  # shellcheck disable=SC2086
-  DOCKER_TEST_OUTPUT=$(docker run --rm ${DOCKER_TEST_IMAGE} --ignore-stdin -p HhBb ${HTTPIE_ADDITIONAL_OPTIONS} GET "${DOCKER_TEST_PROTO}://${DOCKER_TEST_IP}:${DOCKER_TEST_PORT}/${DOCKER_TEST_PATH}" ${HTTPIE_REQ_HEADERS})
-  #shellcheck disable=SC2181
-  if [ $? -ne 0 ]; then
-    echo -e "Failed to get the data"
-    exit 11
-  fi
+
+  # The container is started detached just before this call, so the first
+  # request can race nginx still binding its socket (connection refused/host
+  # unreachable). Retry the request until it connects, then fail loudly.
+  HTTP_TEST_ATTEMPTS=15
+  HTTP_TEST_ATTEMPT=1
+  while : ; do
+    # shellcheck disable=SC2086
+    DOCKER_TEST_OUTPUT=$(docker run --rm ${DOCKER_TEST_IMAGE} --ignore-stdin -p HhBb ${HTTPIE_ADDITIONAL_OPTIONS} GET "${DOCKER_TEST_PROTO}://${DOCKER_TEST_IP}:${DOCKER_TEST_PORT}/${DOCKER_TEST_PATH}" ${HTTPIE_REQ_HEADERS}) && break
+    if [ "${HTTP_TEST_ATTEMPT}" -ge "${HTTP_TEST_ATTEMPTS}" ]; then
+      echo -e "Failed to get the data after ${HTTP_TEST_ATTEMPTS} attempts"
+      docker logs "${CONTAINER_ID}"
+      exit 11
+    fi
+    debug "Request failed (attempt ${HTTP_TEST_ATTEMPT}/${HTTP_TEST_ATTEMPTS}); nginx may still be starting, retrying in 1s"
+    HTTP_TEST_ATTEMPT=$((HTTP_TEST_ATTEMPT + 1))
+    sleep 1
+  done
 }
 
 parse_http_test_output() {


### PR DESCRIPTION
## Problem

The test harness starts each nginx container detached (`docker run -d`) and immediately issues the first request against it. When nginx has not finished binding its socket, that first request fails with `Connection refused` (Errno 111) or `Host is unreachable` (Errno 113), and `get_http_test_output` aborts the whole suite with exit code 11.

This is a startup race, not a regression: it appears intermittently and on a single matrix leg (most recently the CORS scenario on the `1.30.2-alpine-slim-rootless` image in PR #125), while the same image passes on a re-run.

## Fix

`get_http_test_output` now retries the request up to 15 times at 1-second intervals until it connects. Only after exhausting the attempts does it fail — and it then dumps the container logs to aid debugging.

The happy path is unchanged: the first successful response breaks the loop immediately, so a healthy container adds no delay. The retry triggers only on a failed request, so it cannot mask an assertion failure (assertions run against the response after a successful connection).

## Validation

- `shellcheck` clean on `tests/lib/functions.sh`.
- Ran the full rootless suite locally against `1.30.2-alpine-slim.d8-rootless`: 192 assertions OK, no connection errors.
