### PR TITLE
fix(nginx): disable fastcgi_keep_conn to prevent stalled requests on nginx >= 1.29.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   path.
 - The rolling `:d8` / `:d8-rootless` tags, which were gated on a base version
   absent from the build matrix and therefore never published.
+- Intermittent stalled FastCGI requests on nginx >= 1.29.7 (including the
+  default `1.30.2` base). nginx 1.29.7 enabled upstream `keepalive` by default,
+  which combined with the template's `fastcgi_keep_conn on` and an untuned
+  `upstream php` block made nginx reuse FastCGI connections PHP-FPM had already
+  closed, hanging requests until `fastcgi_read_timeout`. `fastcgi_keep_conn` is
+  now set to `off`, restoring the per-request connection behaviour that held on
+  nginx < 1.29.7.
 
 ### Security
 

--- a/templates/fastcgi.conf
+++ b/templates/fastcgi.conf
@@ -38,7 +38,13 @@ fastcgi_buffers 16 32k;
 fastcgi_buffer_size 32k;
 fastcgi_intercept_errors on;
 fastcgi_read_timeout ${NGINX_PHP_READ_TIMEOUT};
-fastcgi_keep_conn on;
+# Do not keep FastCGI connections open for reuse. The `upstream php` block has
+# no `keepalive` directive and PHP-FPM is not tuned for safe connection reuse,
+# so pooling stale connections is unsafe. This was inert before nginx 1.29.7
+# (upstream keepalive defaulted off), but 1.29.7 enabled upstream keepalive by
+# default, which combined with `fastcgi_keep_conn on` made nginx reuse FastCGI
+# connections PHP-FPM had already closed, causing intermittent stalled requests.
+fastcgi_keep_conn off;
 fastcgi_index index.php;
 
 fastcgi_hide_header "Date";


### PR DESCRIPTION
> :robot: _This was written by an AI agent on behalf of @lussoluca._

## Summary

Sets `fastcgi_keep_conn off;` in `templates/fastcgi.conf` to fix intermittent stalled FastCGI requests on nginx >= 1.29.7 (including the default `1.30.2` base).

Closes #127.

## Background

`templates/fastcgi.conf` set `fastcgi_keep_conn on;`, while `upstream php` in `templates/default.conf` has no `keepalive` directive or tuning, and PHP-FPM is not configured for safe connection reuse.

nginx 1.29.7 ([CHANGES-1.30](https://nginx.org/en/CHANGES-1.30)) enabled the upstream `keepalive` directive by default. Before 1.29.7 the lack of `keepalive N` in the upstream block made `fastcgi_keep_conn on` inert (one connection per request). From 1.29.7 on, nginx pools and reuses FastCGI connections to PHP-FPM. When PHP-FPM has already closed a pooled connection, the next request goes into a dead or desynced connection and hangs until `fastcgi_read_timeout`. The failure is intermittent, depending on which pooled connection is reused.

## Evidence

Upstream nginx `alpine-slim` images, same `upstream {}` + `proxy_pass` config (no `keepalive` directive), 5 sequential client requests, counting new backend TCP connections:

| nginx | backend connections | reuse |
| --- | --- | --- |
| 1.25.1 | 5 | no |
| 1.29.6 | 5 | no |
| 1.29.7 | 1 | yes |
| 1.30.2 | 1 | yes |

The default flips exactly at 1.29.7 and persists in 1.30.2.

## Change

- `templates/fastcgi.conf`: `fastcgi_keep_conn on` -> `off`, with an explanatory comment.
- `CHANGELOG.md`: entry under `[Unreleased] / Fixed`.

This restores the per-request connection behaviour that held on nginx < 1.29.7 and is safe across all supported versions. A tuned opt-in keepalive (explicit `keepalive`/`keepalive_timeout`/`keepalive_requests` coordinated with PHP-FPM) could follow as a separate enhancement.

## Testing

Not run locally (the change is a template directive plus a changelog entry, no shell). CI builds and the `tests/tests.sh` harness exercise the images on the branch.